### PR TITLE
tools: Add scripts to "validate" ELF files

### DIFF
--- a/tools/ebpf-check/Makefile
+++ b/tools/ebpf-check/Makefile
@@ -1,0 +1,15 @@
+ISA_REF := instruction-set.rst
+JSON_TABLE := instructions.json
+
+all: $(JSON_TABLE)
+
+$(ISA_REF):
+	./get-from-gh.sh
+
+$(JSON_TABLE): $(ISA_REF)
+	./docs-to-ops.py > $@
+
+clean:
+	$(RM) -- $(ISA_REF) $(JSON_TABLE)
+
+.PHONY: all clean

--- a/tools/ebpf-check/README.md
+++ b/tools/ebpf-check/README.md
@@ -1,0 +1,53 @@
+# Validation Tools for eBPF Standard
+
+/!\\ These tools (and the standard itself) are works in progress.
+
+## Dependencies
+
+awk, curl, llvm-objdump, pyelftools
+
+## Setup
+
+```
+$ make
+```
+
+The command above should create two files. The first one is the RST
+documentation for the eBPF ISA, retrieved with `get-from-gh.sh` from the
+relevant branch in the GitHub repository, and saved locally as
+`instruction-set.rst`.
+
+Then `make` creates the second file by running `docs-to-ops.py` and saving the
+output into `instructions.json`, to produce a JSON list of valid instructions
+from the RST docs.
+
+## Run
+
+After the list of instructions has been generated, call `ebpf-check.py` to
+check an object file. You can pass one or more ELF section names to tell the
+script which sections to check in the object file.
+
+```
+$ ebpf-check.py -h
+usage: ebpf-check.py [-h] [--sections SECTIONS] filename
+
+Check instructions in provided ELF file and section for compliance with the eBPF ISA specification
+
+positional arguments:
+  filename             input ELF object file
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --sections SECTIONS  ELF section names
+```
+
+## Run on multiple object files
+
+For convenience, `check-obj-in-dir.sh` is provided to validate all `TEXT`
+sections in multiple ELF files at once. Example usage:
+
+```
+$ cd cilium/bpf
+$ make -j
+$ /path/to/check-obj-in-dir.sh .
+```

--- a/tools/ebpf-check/check-obj-in-dir.sh
+++ b/tools/ebpf-check/check-obj-in-dir.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+usage() {
+    printf 'Usage: %s <dirname>\n' "$0"
+    printf '\tCheck all sections in .o ELF object files directly under <dirname>\n'
+    exit $1
+}
+
+if [[ $# -lt 1 ]]; then
+    usage 1
+fi
+
+SCRIPT_DIR="$(dirname "$0")"
+
+for file in "$1"/*.o; do
+    sections=""
+
+    for i in $(llvm-objdump -h "${file}" | awk '/TEXT$/ { print $2 }'); do
+        if [[ -z "${sections}" ]]; then
+            sections="$i"
+        else
+            sections="${sections},$i"
+        fi
+    done
+
+    echo "File ${file}: ${SCRIPT_DIR}/ebpf-check.py ${file} --sections ${sections}"
+    "${SCRIPT_DIR}"/ebpf-check.py "${file}" --sections "${sections}"
+done

--- a/tools/ebpf-check/docs-to-ops.py
+++ b/tools/ebpf-check/docs-to-ops.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import re
+
+__hex = '0[xX][0-9a-fA-F]+'
+HEX_RE = re.compile(__hex)
+OP_RE = re.compile(f'^({__hex})\s+(any|{__hex})\s+(any|{__hex}).*')
+
+class OpNotFound(BaseException):
+    pass
+
+def hex_to_dec(val):
+    is_hex = HEX_RE.match(val)
+    return int(val, 16) if is_hex else val
+
+class Parser(object):
+    def __init__(self, filename):
+        self.reader = open(filename, 'r')
+        self.line = ''
+        self.ops = []
+
+    def seek_to(self, target, help_message):
+        self.reader.seek(0)
+        offset = self.reader.read().find(target)
+        if offset == -1:
+            raise Exception(help_message)
+        self.reader.seek(offset)
+        self.reader.readline()
+        self.line = self.reader.readline()
+
+    def parse_line(self):
+        capture = OP_RE.match(self.line)
+        if not capture:
+            raise OpNotFound
+
+        self.ops.append({
+            'opc' : hex_to_dec(capture.group(1)),
+            'src' : hex_to_dec(capture.group(2)),
+            'imm' : hex_to_dec(capture.group(3))
+        })
+
+    def run(self):
+        self.seek_to('Appendix',
+                     'Could not find "Appendix" section')
+
+        p = re.compile('^0[xX]')
+        while True:
+            self.line = self.reader.readline()
+            if not self.line:
+                break
+            is_op = p.match(self.line)
+            if not is_op:
+                continue
+            self.parse_line()
+
+        self.reader.close()
+
+    def print(self):
+        print(json.dumps(self.ops, indent=2))
+
+if __name__ == '__main__':
+    input = os.path.join(os.getcwd(), 'instruction-set.rst')
+
+    description='Convert eBPF ISA doc to a list of existing instructions (JSON)'
+    argParser = argparse.ArgumentParser(description=description)
+    if (os.path.isfile(input)):
+        argParser.add_argument('--filename', help='input file', default=input)
+    else:
+        argParser.add_argument('--filename', help='input file')
+    args = argParser.parse_args()
+
+    # Parse file.
+    parser = Parser(args.filename)
+    parser.run()
+
+    # Print formatted output to standard output.
+    parser.print()

--- a/tools/ebpf-check/ebpf-check.py
+++ b/tools/ebpf-check/ebpf-check.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+
+import json
+
+from elftools.elf.elffile import ELFFile
+
+OPS_JON = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])),
+                       'instructions.json')
+
+class ISA(object):
+    def __init__(self):
+        file = open(OPS_JON, 'r')
+        self.ops = json.load(file)
+        file.close()
+
+def get_insn(insn):
+    if sys.byteorder == 'little':
+        return {
+            'opc': insn[0],
+            'dst': insn[1] & 0x0f,
+            'src': (insn[1] & 0xf0) >> 4,
+            'off': insn[2] + (insn[3] << 8),
+            'imm': insn[4] + (insn[5] << 8) + (insn[6] << 16) + (insn[7] << 24)
+        }
+    else:
+        return {
+            'opc': insn[7],
+            'dst': (insn[6] & 0xf0) >> 4,
+            'src': insn[6] & 0x0f,
+            'off': insn[5] + (insn[4] << 8),
+            'imm': insn[3] + (insn[2] << 8) + (insn[1] << 16) + (insn[0] << 24)
+        }
+
+def process_insn(isa, prev_insn_data, insn_data, next_insn_data,
+                 filename, section_name, insn_nb):
+    is_valid = False
+    insn = get_insn(insn_data)
+
+    for op in isa.ops:
+        if op['opc'] == insn['opc']:
+            if op['src'] != 'any' and op['src'] != insn['src']:
+                continue
+            if op['imm'] != 'any' and op['imm'] != insn['imm']:
+                continue
+            is_valid = True
+            break
+
+    if not is_valid:
+        print(f'{filename}:{section_name}:{insn_nb}:{insn}: Not a valid instruction')
+        return is_valid
+
+    # Check that 0x18 is 16-bytes long and followed by a 0x00 opcode
+    if insn['opc'] == 0x18:
+        next_insn = get_insn(next_insn_data)
+        if not next_insn:
+            print(f'{filename}:{section_name}:{insn_nb}:{insn}: 0x18 misses its second half-instruction')
+            is_valid = False
+        if next_insn['opc'] != 0x00:
+            print(f'{filename}:{section_name}:{insn_nb}:{insn}: 0x18 not followed by 0x00 second half-instruction')
+            is_valid = False
+
+    # Check that 0x00 opcode is preceeded by 0x18
+    if insn['opc'] == 0x00:
+        prev_insn = get_insn(prev_insn_data)
+        if prev_insn['opc'] != 0x18:
+            print(f'{filename}:{section_name}:{insn_nb}:{insn}: 0x00 not preceeded by 0x18 first half-instruction')
+            is_valid = False
+
+    return is_valid
+
+def process_section(isa, section, filename):
+    insn_size = 8
+    if section.data_size % insn_size:
+        raise Exception(f'Data length in section {section.name} is not a multiple of {insn_size} bytes')
+
+    is_valid = True
+    insn = {}
+    next_insn = section.data()[0:insn_size]
+    for i in range(section.data_size // insn_size - 1):
+        prev_insn = insn
+        insn = next_insn
+        if i == (section.data_size // insn_size - 1):
+            next_insn = {}
+        else:
+            next_insn = section.data()[(i+1)*insn_size:(i+2)*insn_size]
+        if not process_insn(isa, prev_insn, insn, next_insn,
+                            filename, section.name, i):
+            is_valid = False
+
+    return is_valid
+
+def process_file(isa, filename, section_names):
+    is_valid = True
+    with open(filename, 'rb') as f:
+        elffile = ELFFile(f)
+        for section_name in section_names.split(','):
+            section = elffile.get_section_by_name(section_name)
+            if not section:
+                raise Exception(f'File {filename}: section "{section_name}" not found!')
+            if not process_section(isa, section, filename):
+                is_valid = False
+
+        f.close()
+
+    return is_valid
+
+if __name__ == '__main__':
+    description='Check instructions in provided ELF file and section for compliance with the eBPF ISA specification'
+    argParser = argparse.ArgumentParser(description=description)
+    argParser.add_argument('filename', help='input ELF object file')
+    argParser.add_argument('--sections', help='Comma-separated list of ELF section names',
+                           default='.text')
+    args = argParser.parse_args()
+
+    isa = ISA()
+    if not process_file(isa, args.filename, args.sections):
+        sys.exit(1)

--- a/tools/ebpf-check/get-from-gh.sh
+++ b/tools/ebpf-check/get-from-gh.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl -LO 'https://raw.githubusercontent.com/ebpffoundation/ebpf-docs/update/rst/instruction-set.rst'


### PR DESCRIPTION
Add a set of scripts to:

- Retrieve the latest RST ISA doc from the "update" branch in the GitHub repository (currently used for the PR for updating the document)

- Generate a JSON list of valid instructions from the RST document

- Check ELF file sections for validity against the list of instructions. The checks currently include:
   - Checking that we have known opcodes with valid `src` and `imm` fields, as mentioned in the table in the Appendix of the RST doc.
   - For `0x18` (load double word + extended instructions): checking that 0x18 opcodes are followed by `0x00` opcodes, and conversely that `0x00` are always preceeded by `0x18`.

- Run the previous script as a batch on all sections for all .o files in a directory (example use case: run on all Cilium programs)

This is work in progress and should not be considered an official validation tool at this stage.

Once the eBPF specification gets closer to a final version, we will probably stop converting the table from the RST file and keep a reference JSON list instead (so we can also add constraints on the offset and destination register fields). In the meantime, it is easier to pull the latest adjustments this way.

Besides validation of existing programs, the scripts can be helpful to check we cover instructions existing today in deployed eBPF programs.