### PR TITLE
tools/ebpf-check: Fix missing comma in docs-to-ops.py

### DIFF
--- a/tools/ebpf-check/README.md
+++ b/tools/ebpf-check/README.md
@@ -53,5 +53,5 @@ files at once. For example:
 ```
 $ cd cilium/bpf
 $ make -j
-$ /path/to/ebpf-check.py --all-sections *.o
+$ /path/to/ebpf-check.py *.o
 ```

--- a/tools/ebpf-check/docs-to-ops.py
+++ b/tools/ebpf-check/docs-to-ops.py
@@ -39,7 +39,7 @@ class Parser(object):
         insn = {
             'opc' : hex_to_dec(capture.group(1)),
             'src' : hex_to_dec(capture.group(2)),
-            'imm' : hex_to_dec(capture.group(3))
+            'imm' : hex_to_dec(capture.group(3)),
             'dsc' : capture.group(4),
             'cat' : capture.group(5),
         }


### PR DESCRIPTION
It looks like I had some uncommitted changes in my repository when testing `docs-to-ops.py` for the last PR, and I failed to notice the missing comma. Let's address it.

---

Unrelated to the PR, the script passes on all kernel selftests files (tested at commit 5ee35abb461e, compiled with clang-16), without reporting any invalid instructions.

```
$ find ~/dev/linux/tools/testing/selftests/bpf -type f -name '*.bpf.o' | \
        xargs ~/dev/ebpf-docs/tools/ebpf-check/ebpf-check.py
<no output>
```

This means that we're unlikely to have any false positives (when looking for invalid instructions), although it doesn't tell if there's any false negative (invalid instructions we failed to detect).