### PR TITLE
Fix appendix entry for call instruction

### DIFF
--- a/rst/instruction-set-opcodes.rst
+++ b/rst/instruction-set-opcodes.rst
@@ -120,7 +120,7 @@ opcode  src  imm   offset  description                                          
 0x7f    any  0x00  0       dst >>= src                                          `Arithmetic instructions`_
 0x84    0x0  0x00  0       dst = (u32)-dst                                      `Arithmetic instructions`_
 0x85    0x0  any   0       call platform-agnostic helper function imm           `Helper functions`_
-0x85    0x1  any   any     call PC += offset                                    `Program-local functions`_
+0x85    0x1  any   any     call PC += imm                                       `Program-local functions`_
 0x85    0x2  any   0       call platform-specific helper function imm           `Helper functions`_
 0x87    0x0  0x00  0       dst = -dst                                           `Arithmetic instructions`_
 0x94    0x0  any   0       dst = (u32)((imm != 0) ? (dst % imm) : dst)          `Arithmetic instructions`_

--- a/rst/instruction-set-skeleton.rst
+++ b/rst/instruction-set-skeleton.rst
@@ -52,7 +52,7 @@ Acknowledgements
 
 This draft was generated from instruction-set.rst in the Linux
 kernel repository, to which a number of other individuals have authored contributions
-over time, including Akhil Raj, Christoph Hellwig, Jose E. Marchesi, Kosuke Fujimoto,
+over time, including Akhil Raj, Will Hawkins, Christoph Hellwig, Jose E. Marchesi, Kosuke Fujimoto,
 Shahab Vahedi, Tiezhu Yang, and Zheng Yejian, with review and suggestions by many others including
 Alan Jowett, Alexei Starovoitov, Andrii Nakryiko, Daniel Borkmann, David Vernet, Jim Harris,
 Quentin Monnet, Song Liu, Shung-Hsi Yu, Stanislav Fomichev, and Yonghong Song.


### PR DESCRIPTION
See https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/Documentation/bpf/standardization/instruction-set.rst?id=2d71a90f7e0fa3cd348602a36f6eb1237ab7cebb