### PR TITLE
Add new instructions from clang cpu v4 to opcode table in appendix

### DIFF
--- a/rst/instruction-set-opcodes.rst
+++ b/rst/instruction-set-opcodes.rst
@@ -8,6 +8,7 @@ opcode  src  imm   offset  description                                          
 0x00    0x0  any   0       (additional immediate value)                         `64-bit immediate instructions`_
 0x04    0x0  any   0       dst = (u32)((u32)dst + (u32)imm)                     `Arithmetic instructions`_
 0x05    0x0  0x00  0       goto +offset                                         `Jump instructions`_
+0x06    0x0  0x00  0       goto +imm                                            `Jump instructions`_
 0x07    0x0  any   0       dst += imm                                           `Arithmetic instructions`_
 0x0c    any  0x00  0       dst = (u32)((u32)dst + (u32)src)                     `Arithmetic instructions`_
 0x0f    any  0x00  0       dst += src                                           `Arithmetic instructions`_

--- a/rst/instruction-set-opcodes.rst
+++ b/rst/instruction-set-opcodes.rst
@@ -196,6 +196,9 @@ opcode  src  imm   offset  description                                          
 0xd4    0x0  0x40  0       dst = htole64(dst)                                   `Byte swap instructions`_
 0xd5    0x0  any   any     if dst s<= imm goto +offset                          `Jump instructions`_
 0xd6    0x0  any   any     if (s32)dst s<= (s32)imm goto +offset                `Jump instructions`_
+0xd7    0x0  0x10  0       dst = bswap16(dst)                                   `Byte swap instructions`_
+0xd7    0x0  0x20  0       dst = bswap32(dst)                                   `Byte swap instructions`_
+0xd7    0x0  0x40  0       dst = bswap64(dst)                                   `Byte swap instructions`_
 0xdb    any  0x00  any     lock \*(u64 \*)(dst + offset) += src                 `Atomic operations`_
 0xdb    any  0x01  any     lock::                                               `Atomic operations`_
 

--- a/rst/instruction-set-opcodes.rst
+++ b/rst/instruction-set-opcodes.rst
@@ -47,17 +47,21 @@ opcode  src  imm   offset  description                                          
 0x32    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
 0x33    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
 0x34    0x0  any   0       dst = (u32)((imm != 0) ? (dst / imm) : 0)            `Arithmetic instructions`_
+0x34    0x0  any   1       dst = (u32)((imm != 0) ? (dst s/ imm) : 0)           `Arithmetic instructions`_
 0x35    0x0  any   any     if dst >= imm goto +offset                           `Jump instructions`_
 0x36    0x0  any   any     if (u32)dst >= imm goto +offset                      `Jump instructions`_
 0x37    0x0  any   0       dst = (imm != 0) ? (dst / imm) : 0                   `Arithmetic instructions`_
+0x37    0x0  any   1       dst = (imm != 0) ? (dst s/ imm) : 0                  `Arithmetic instructions`_
 0x38    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
 0x39    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
 0x3a    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
 0x3b    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
 0x3c    any  0x00  0       dst = (u32)((imm != 0) ? (dst / src) : 0)            `Arithmetic instructions`_
+0x3c    any  0x00  1       dst = (u32)((imm != 0) ? (dst s/ src) : 0)           `Arithmetic instructions`_
 0x3d    any  0x00  any     if dst >= src goto +offset                           `Jump instructions`_
 0x3e    any  0x00  any     if (u32)dst >= (u32)src goto +offset                 `Jump instructions`_
 0x3f    any  0x00  0       dst = (src != 0) ? (dst / src) : 0                   `Arithmetic instructions`_
+0x3f    any  0x00  1       dst = (src != 0) ? (dst s/ src) : 0                  `Arithmetic instructions`_
 0x40    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
 0x41    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
 0x42    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_

--- a/rst/instruction-set-opcodes.rst
+++ b/rst/instruction-set-opcodes.rst
@@ -146,9 +146,14 @@ opcode  src  imm   offset  description                                          
 0xae    any  0x00  any     if (u32)dst < (u32)src goto +offset                  `Jump instructions`_
 0xaf    any  0x00  0       dst ^= src                                           `Arithmetic instructions`_
 0xb4    0x0  any   0       dst = (u32) imm                                      `Arithmetic instructions`_
+0xb4    0x0  any   8       dst = (u32) (s32) (s8) imm                           `Arithmetic instructions`_
+0xb4    0x0  any   16      dst = (u32) (s32) (s16) imm                          `Arithmetic instructions`_
 0xb5    0x0  any   any     if dst <= imm goto +offset                           `Jump instructions`_
 0xa6    0x0  any   any     if (u32)dst <= imm goto +offset                      `Jump instructions`_
 0xb7    0x0  any   0       dst = imm                                            `Arithmetic instructions`_
+0xb7    0x0  any   8       dst = (s64) (s8) imm                                 `Arithmetic instructions`_
+0xb7    0x0  any   16      dst = (s64) (s16) imm                                `Arithmetic instructions`_
+0xb7    0x0  any   32      dst = (s64) (s32) imm                                `Arithmetic instructions`_
 0xbc    any  0x00  0       dst = (u32) src                                      `Arithmetic instructions`_
 0xbd    any  0x00  any     if dst <= src goto +offset                           `Jump instructions`_
 0xbe    any  0x00  any     if (u32)dst <= (u32)src goto +offset                 `Jump instructions`_

--- a/rst/instruction-set-opcodes.rst
+++ b/rst/instruction-set-opcodes.rst
@@ -128,10 +128,14 @@ opcode  src  imm   offset  description                                          
 0x85    0x2  any   0       call platform-specific helper function imm           `Helper functions`_
 0x87    0x0  0x00  0       dst = -dst                                           `Arithmetic instructions`_
 0x94    0x0  any   0       dst = (u32)((imm != 0) ? (dst % imm) : dst)          `Arithmetic instructions`_
+0x94    0x0  any   1       dst = (u32)((imm != 0) ? (dst s% imm) : dst)         `Arithmetic instructions`_
 0x95    0x0  0x00  0       return                                               `Jump instructions`_
 0x97    0x0  any   0       dst = (imm != 0) ? (dst % imm) : dst                 `Arithmetic instructions`_
+0x97    0x0  any   1       dst = (imm != 0) ? (dst s% imm) : dst                `Arithmetic instructions`_
 0x9c    any  0x00  0       dst = (u32)((src != 0) ? (dst % src) : dst)          `Arithmetic instructions`_
+0x9c    any  0x00  1       dst = (u32)((src != 0) ? (dst s% src) : dst)         `Arithmetic instructions`_
 0x9f    any  0x00  0       dst = (src != 0) ? (dst % src) : dst                 `Arithmetic instructions`_
+0x9f    any  0x00  1       dst = (src != 0) ? (dst s% src) : dst                `Arithmetic instructions`_
 0xa4    0x0  any   0       dst = (u32)(dst ^ imm)                               `Arithmetic instructions`_
 0xa5    0x0  any   any     if dst < imm goto +offset                            `Jump instructions`_
 0xa6    0x0  any   any     if (u32)dst < imm goto +offset                       `Jump instructions`_


### PR DESCRIPTION
* add BPF_SDIV
* add BPF_SMOD
* add BPF_MOVSX
* add BPF_ALU64 | BPF_TO_LE
* add BPF_JA BPF_JMP32

See https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/Documentation/bpf/standardization/instruction-set.rst?id=245d4c40c09bd8d5a71640950eeb074880925b9a

Fixes #37