### PR TITLE
Fix typo in opcode table imm column

### DIFF
--- a/rst/instruction-set-opcodes.rst
+++ b/rst/instruction-set-opcodes.rst
@@ -57,8 +57,8 @@ opcode  src  imm   offset  description                                          
 0x39    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
 0x3a    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
 0x3b    any  any   any     (deprecated, implementation-specific)                `Legacy BPF Packet access instructions`_
-0x3c    any  any   0       dst = (u32)((src != 0) ? ((u32)dst / (u32)src) : 0)  `Arithmetic instructions`_
-0x3c    any  any   1       dst = (u32)((src != 0) ? ((s32)dst s/(s32)src) : 0)  `Arithmetic instructions`_
+0x3c    any  0x00  0       dst = (u32)((src != 0) ? ((u32)dst / (u32)src) : 0)  `Arithmetic instructions`_
+0x3c    any  0x00  1       dst = (u32)((src != 0) ? ((s32)dst s/(s32)src) : 0)  `Arithmetic instructions`_
 0x3d    any  0x00  any     if dst >= src goto +offset                           `Jump instructions`_
 0x3e    any  0x00  any     if (u32)dst >= (u32)src goto +offset                 `Jump instructions`_
 0x3f    any  0x00  0       dst = (src != 0) ? (dst / src) : 0                   `Arithmetic instructions`_


### PR DESCRIPTION
imm column value was incorrect for two rows