### PR TITLE
Add explicit abstract separate from Introduction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build xml files
       run: |
-        wget https://github.com/dthaler/rst2rfcxml/releases/download/v1.3.0/Ubuntu.Release.rst2rfcxml.zip
+        wget https://github.com/dthaler/rst2rfcxml/releases/download/v1.4.0/Ubuntu.Release.rst2rfcxml.zip
         unzip Ubuntu.Release.rst2rfcxml.zip
         chmod 755 rst2rfcxml
         ./rst2rfcxml rst/instruction-set-skeleton.rst -o generated/draft-ietf-bpf-isa.xml

--- a/rst/instruction-set-skeleton.rst
+++ b/rst/instruction-set-skeleton.rst
@@ -2,6 +2,7 @@
 .. |ipr| replace:: trust200902
 .. |category| replace:: std
 .. |titleAbbr| replace:: BPF ISA
+.. |abstract| replace:: This document specifies the BPF instruction set architecture (ISA).
 .. |submissionType| replace:: IETF
 .. |author[0].fullname| replace:: Dave Thaler
 .. |author[0].role| replace:: editor


### PR DESCRIPTION
Per recent support added to rst2rfcxml.

This PR keeps the abstract the same, while a patch to create an introduction is going through review on the list.