### PR TITLE
Make abstract match introduction

### DIFF
--- a/rst/instruction-set-skeleton.rst
+++ b/rst/instruction-set-skeleton.rst
@@ -2,7 +2,6 @@
 .. |ipr| replace:: trust200902
 .. |category| replace:: std
 .. |titleAbbr| replace:: BPF ISA
-.. |abstract| replace:: This document specifies the BPF instruction set architecture (ISA).
 .. |submissionType| replace:: IETF
 .. |author[0].fullname| replace:: Dave Thaler
 .. |author[0].role| replace:: editor


### PR DESCRIPTION
Remove the glossary override and let rst2rfcxml use the introduction as the default abstract.

Addresses #134